### PR TITLE
fix: use simple release-type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,4 @@ jobs:
         id: please
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          release-type: php
+          release-type: simple

--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,7 @@
         "symfony/polyfill-php73": "*",
         "symfony/polyfill-php74": "*",
         "symfony/polyfill-php80": "*",
-        "symfony/polyfill-php81": "*",
-        "version": "0.5.0"
+        "symfony/polyfill-php81": "*"
     },
     "scripts": {
         "auto-scripts": {


### PR DESCRIPTION
as php seems buggy : "replace.version is invalid, it should have a vendor name, a forward slash, "