### PR TITLE
ci: refactor preview and main env variable substitution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,28 @@ jobs:
         stack-name: yazoo-preview
         stack-definition: etc/stack.yaml
         image: ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
-        template-variables: ${{ secrets.YAZOO_PREVIEW_VARS }}
+        template-variables: |
+          {
+            "APP_ENV": "${{ env.APP_ENV }}",
+            "APP_HOSTNAME": "${{ env.APP_HOSTNAME }}",
+            "APP_SECRET": "${{ secrets.APP_SECRET }}",
+            "CADDY_EMAIL": "${{ secrets.CADDY_EMAIL }}",
+            "CADDY_EXTRA_CONFIG": "${{ env.CADDY_EXTRA_CONFIG }}",
+            "CADDY_GLOBAL_OPTIONS": "${{ env.CADDY_GLOBAL_OPTIONS }}",
+            "DIRECTUS_EMAIL": "${{ secrets.DIRECTUS_EMAIL }}",
+            "DIRECTUS_PASSWORD": "${{ secrets.DIRECTUS_PASSWORD }}",
+            "MARIADB_CHARSET": "${{ env.MARIADB_CHARSET }}",
+            "MARIADB_DATABASE": "${{ secrets.MARIADB_DATABASE }}",
+            "MARIADB_HOST": "${{ secrets.MARIADB_HOST }}",
+            "MARIADB_PASSWORD": "${{ secrets.MARIADB_PASSWORD }}",
+            "MARIADB_PORT": "${{ secrets.MARIADB_PORT }}",
+            "MARIADB_RANDOM_ROOT_PASSWORD": "true",
+            "MARIADB_USER": "${{ secrets.MARIADB_USER }}",
+            "MARIADB_VERSION": "${{ secrets.MARIADB_VERSION }}",
+            "SERVER_NAME": "http://${{ env.APP_HOSTNAME }}",
+            "STACK_NAME": "yazoo-preview",
+            "YOUTUBE_API_KEY": "${{ secrets.YOUTUBE_API_KEY }}"
+          }
 
   main:
     needs: [image]
@@ -78,4 +99,25 @@ jobs:
         stack-name: yazoo-main
         stack-definition: etc/stack.yaml
         image: ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
-        template-variables: ${{ secrets.YAZOO_PROD_VARS }}
+        template-variables: |
+          {
+            "APP_ENV": "${{ env.APP_ENV }}",
+            "APP_HOSTNAME": "${{ env.APP_HOSTNAME }}",
+            "APP_SECRET": "${{ secrets.APP_SECRET }}",
+            "CADDY_EMAIL": "${{ secrets.CADDY_EMAIL }}",
+            "CADDY_EXTRA_CONFIG": "${{ env.CADDY_EXTRA_CONFIG }}",
+            "CADDY_GLOBAL_OPTIONS": "${{ env.CADDY_GLOBAL_OPTIONS }}",
+            "DIRECTUS_EMAIL": "${{ secrets.DIRECTUS_EMAIL }}",
+            "DIRECTUS_PASSWORD": "${{ secrets.DIRECTUS_PASSWORD }}",
+            "MARIADB_CHARSET": "${{ env.MARIADB_CHARSET }}",
+            "MARIADB_DATABASE": "${{ secrets.MARIADB_DATABASE }}",
+            "MARIADB_HOST": "${{ secrets.MARIADB_HOST }}",
+            "MARIADB_PASSWORD": "${{ secrets.MARIADB_PASSWORD }}",
+            "MARIADB_PORT": "${{ secrets.MARIADB_PORT }}",
+            "MARIADB_RANDOM_ROOT_PASSWORD": "true",
+            "MARIADB_USER": "${{ secrets.MARIADB_USER }}",
+            "MARIADB_VERSION": "${{ secrets.MARIADB_VERSION }}",
+            "SERVER_NAME": "http://${{ env.APP_HOSTNAME }}",
+            "STACK_NAME": "yazoo-main",
+            "YOUTUBE_API_KEY": "${{ secrets.YOUTUBE_API_KEY }}"
+          }


### PR DESCRIPTION
Variables are now managed in [github environments](https://github.com/constructions-incongrues/yazoo/settings/environments).

Fixes #90